### PR TITLE
fix daemonize

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ struct Cli {
     #[arg(long)]
     http_basic: Option<String>,
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(unix)]
     /// Run process in background
     #[arg(short, long, default_value_t = false)]
     detached: bool,
@@ -64,7 +64,7 @@ struct Cli {
 
 fn main() {
     let args = Cli::parse();
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(unix)]
     {
         if args.detached {
             let daemonize = daemonize::Daemonize::new();


### PR DESCRIPTION
The [daemonize](https://docs.rs/daemonize/latest/daemonize/) library executes `libc::exit` in parent processes, which means there's no opportunity for destructors to be invoked. This makes incoming requests hit the unrecycled runtime.

Since [std::os::unix](https://docs.rs/crate/daemonize/latest/source/src/lib.rs#55-56) is used in the library, it's more precise to use `unix` as a build condition.